### PR TITLE
[IMP] tag: tag requirements before tagging project

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Future (?)
 - [IMP] tag_requirements: fetch more aggressively; this solves the errors
   trying to write ref with non existent object
 - [IMP] tag: always tag requirements when doing acsoo tag
+- [IMP] tag: tag requirements before tagging project, so if something fails
+  when tagging the requirements the project is not tagged and the release 
+  build is not triggered.
 
 1.4.3 (2017-06-16)
 ------------------

--- a/acsoo/tag.py
+++ b/acsoo/tag.py
@@ -26,9 +26,9 @@ def do_tag(config, force, src, requirement, yes):
     if out:
         click.echo(out)
         raise click.ClickException("Please commit first.")
+    do_tag_requirements(config, force, src, requirement, yes=True)
     check_call(['git', 'tag'] + force_cmd + [tag])
     check_call(['git', 'push', '-q'] + force_cmd + ['origin', 'tag', tag])
-    do_tag_requirements(config, force, src, requirement, yes=True)
 
 
 @click.command(help='Tag the current project after ensuring '


### PR DESCRIPTION
so if something fails  when tagging the requirements
the project is not tagged and the release build is not triggered.