### PR TITLE
[ADD] Acsoo addons: list_diff

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,7 @@ A set of commands to print addons lists, useful when running tests.
 
      acsoo addons list
      acsoo addons list-depends
+     acsoo addons list-diff
 
 acsoo checklog
 --------------


### PR DESCRIPTION
### Description
A new extension to acsoo addons allowing to print a comma separated list of modified addons
### Usage
`acsoo addons list-diff {branch_name} --exclude={addons_to_exclude}`

Where:
* `branch_name` is the target branch to compare with (origin/master by default)
* `addons_to_exclude` is a comma separated list of addons to exclude from the output
_Note that this command won't print new addons_

### TODO
- [ ] Update `README.rst`