### PR TITLE
[IMP] Project Template: new build stage in GitLab CI config

### DIFF
--- a/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
+++ b/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
@@ -61,7 +61,8 @@ test:
     - virtualenv --python=$(which {{{ python_version }}}) venv
     - venv/bin/pip install coverage
     - venv/bin/pip install --no-deps --no-index release/*.whl
-    - venv/bin/pip install -e . --no-deps --no-index
+    # although the project is part of *.whl, install it in editable mode so coverage sees it
+    - venv/bin/pip install --no-deps --no-index -e .
     - ADDONS_INIT=$(./acsoo addons list-depends)
     - echo Installing ${ADDONS_INIT}
     - unbuffer venv/bin/{{{ odoocmd }}} -c odoo-ci.cfg -d ${DB_NAME} --stop-after-init --no-xmlrpc -i ${ADDONS_INIT} | ./acsoo checklog

--- a/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
+++ b/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
@@ -1,4 +1,5 @@
 stages:
+  - code quality
   - build
   - test
   - deploy
@@ -37,14 +38,14 @@ build:
       - release/
 
 pylint:
-  stage: test
+  stage: code quality
   tags:
     - python
   script:
     - ./acsoo pylint
 
 flake8:
-  stage: test
+  stage: code quality
   tags:
     - python
   script:

--- a/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
+++ b/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
@@ -1,4 +1,5 @@
 stages:
+  - build
   - test
   - deploy
 
@@ -22,6 +23,19 @@ after_script:
 variables:
   DB_NAME: "${CI_PROJECT_NAME}-${CI_JOB_ID}"
 
+build:
+  stage: build
+  # use odoo-{{{ odoo.series }}} runner so we have the pre-cloned odoo
+  # except for that optimization, we don't need odoo dependencies for this job
+  tags:
+    - odoo-{{{ odoo.series }}}
+  script:
+    - ./acsoo wheel
+  artifacts:
+    expire_in: 1 week
+    paths:
+      - release/
+
 pylint:
   stage: test
   tags:
@@ -43,12 +57,11 @@ flake8:
 {{% endif %}}
 test:
   stage: test
-  tags:
-    - odoo-{{{ odoo.series }}}
   script:
     - virtualenv --python=$(which {{{ python_version }}}) venv
     - venv/bin/pip install coverage
-    - venv/bin/pip install -r requirements.txt -e .
+    - venv/bin/pip install --no-deps --no-index release/*.whl
+    - venv/bin/pip install -e . --no-deps --no-index
     - ADDONS_INIT=$(./acsoo addons list-depends)
     - echo Installing ${ADDONS_INIT}
     - unbuffer venv/bin/{{{ odoocmd }}} -c odoo-ci.cfg -d ${DB_NAME} --stop-after-init --no-xmlrpc -i ${ADDONS_INIT} | ./acsoo checklog
@@ -60,18 +73,17 @@ test:
     - unbuffer venv/bin/coverage run venv/bin/{{{ odoocmd }}} -c odoo-ci.cfg -d ${DB_NAME} --stop-after-init --no-xmlrpc -i ${ADDONS_TEST} --test-enable | ./acsoo checklog
     - venv/bin/coverage report
   coverage: '/TOTAL\s+\d+\s+\d+\s+(\d+\%)/'
+  dependencies:
+    - build
 
 deploy-test:
   stage: deploy
-  tags:
-    # use odoo-10.0 runner so we have the pre-cloned odoo
-    # except for that optimization, we don't need odoo dependencies for this job
-    - odoo-10.0
   script:
-    - ./acsoo wheel
     - ./deploy-test
   environment:
     name: test
     url: https://odoo-{{{ project.name }}}-test.acsone.eu
   only:
     - /^\d+\.\d+\.\d+$/
+  dependencies:
+    - build


### PR DESCRIPTION
A new stage called `build` generating the wheels of the project and store it in an [Artifact](https://docs.gitlab.com/ce/ci/yaml/#artifacts). The wheels are then used in `test` and `deploy` stages.