### PR TITLE
[REF] GitLab CI template: detect missing dependencies

### DIFF
--- a/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
+++ b/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
@@ -61,9 +61,10 @@ test:
   script:
     - virtualenv --python=$(which {{{ python_version }}}) venv
     - venv/bin/pip install coverage
-    - venv/bin/pip install --no-deps --no-index release/*.whl
+    # use --no-index so missing dependencies that would not be in *.whl are detected
+    - venv/bin/pip install --no-index release/*.whl
     # although the project is part of *.whl, install it in editable mode so coverage sees it
-    - venv/bin/pip install --no-deps --no-index -e .
+    - venv/bin/pip install --no-index -e .
     - ADDONS_INIT=$(./acsoo addons list-depends)
     - echo Installing ${ADDONS_INIT}
     - unbuffer venv/bin/{{{ odoocmd }}} -c odoo-ci.cfg -d ${DB_NAME} --stop-after-init --no-xmlrpc -i ${ADDONS_INIT} | ./acsoo checklog


### PR DESCRIPTION
The --no-deps won't check missing dependencies and won't break if there are missing dependencies
By keeping the --no-index only we are sure to detect missing dependencies
From https://github.com/acsone/acsoo/pull/29#pullrequestreview-103926641