### PR TITLE
[FIX] Allow W503 and W504

### DIFF
--- a/acsoo/cfg/flake8.cfg
+++ b/acsoo/cfg/flake8.cfg
@@ -2,6 +2,7 @@
 # E123,E133,E226,E241,E242 are ignored by default by pep8 and flake8
 # F811 is legal in odoo 8 when we implement 2 interfaces for a method
 # F999 pylint support this case with expected tests
-ignore = E123,E133,E226,E241,E242,F811,F601
+# W503 replaced by W504 in latest flake8
+ignore = E123,E133,E226,E241,E242,F811,F601,W503,W504
 max-line-length = 79
 exclude = ./src,./venv*,.eggs/,__init__.py


### PR DESCRIPTION
W503 has been replaced by W504 in latest flake8. To avoid a lot of changes in our existing projects, allows both
cc @sbidoul @acsone/acsone-odoo-team 