### PR TITLE
[FIX] acsoo pylint: Compatible with pylint-odoo 2.0.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changes
 .. ----------
 .. -
 
+- [FIX] acsoo pytlint: Adapt config to also work with pytlint-odoo 2.0.1
 - [IMP] project template: use click-odoo-update
 
 1.8.2 (2018-11-05)

--- a/acsoo/cfg/pylint.cfg
+++ b/acsoo/cfg/pylint.cfg
@@ -86,7 +86,10 @@ readme_template_url=https://github.com/OCA/maintainer-tools/blob/master/template
 extfiles_to_lint=xml,csv,po,js,mako
 
 # Name of author required in manifest file.
+# odoo-pylint < 2.0.1
 manifest_required_author=ACSONE SA/NV
+# odoo-pylint >= 2.0.1
+manifest_required_authors=ACSONE SA/NV
 
 # List of keys required in manifest file, separated by a comma.
 manifest_required_keys=license,author


### PR DESCRIPTION
In pylint-odoo 2.0.1 the paramter 'manifest_required_author' has been renamed into 'manifest_required_authors'.
Both parameters are now provided into the default config to be compatible with pytlint-odoo < 2.0.1 and 2.0.1