### PR TITLE
[FIX] Acsoo PyLint: python3 compatibility

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -6,4 +6,4 @@ force_grid_wrap=0
 combine_as_imports=True
 use_parentheses=True
 line_length=88
-known_third_party = appdirs,click,configparser,pkg_resources,pylint,setuptools
+known_third_party = appdirs,click,pkg_resources,pylint,setuptools

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -6,4 +6,4 @@ force_grid_wrap=0
 combine_as_imports=True
 use_parentheses=True
 line_length=88
-known_third_party = appdirs,click,pkg_resources,pylint,setuptools
+known_third_party = appdirs,click,configparser,pkg_resources,pylint,setuptools

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,11 +18,14 @@ repos:
   rev: v1.6.1
   hooks:
   - id: pyupgrade
+    language_version: python3
 - repo: https://github.com/asottile/seed-isort-config
   rev: v1.3.0
   hooks:
   - id: seed-isort-config
+    language_version: python3
 - repo: https://github.com/pre-commit/mirrors-isort
   rev: v4.3.4
   hooks:
   - id: isort
+    language_version: python3

--- a/acsoo/pylintcmd.py
+++ b/acsoo/pylintcmd.py
@@ -4,10 +4,11 @@
 
 import logging
 import sys
-from configparser import ConfigParser
 
 import click
+import pkg_resources
 import pylint.lint
+from configparser import ConfigParser
 
 from .config import AcsooConfig
 from .main import main
@@ -93,7 +94,12 @@ def do_pylintcmd(load_plugins, rcfile, module, expected, pylint_options):
         + list(module)
     )
     log_cmd(["pylint"] + cmd, level=logging.INFO)
-    lint_res = pylint.lint.Run(cmd[:], exit=False)
+    if pkg_resources.get_distribution(
+        "pylint"
+    ).parsed_version >= pkg_resources.parse_version("2.0"):
+        lint_res = pylint.lint.Run(cmd[:], do_exit=False)  # pylint2
+    else:
+        lint_res = pylint.lint.Run(cmd[:], exit=False)  # pylint1
     sys.stdout.flush()
     sys.stderr.flush()
     expected = _consolidate_expected(rcfile, expected)

--- a/acsoo/pylintcmd.py
+++ b/acsoo/pylintcmd.py
@@ -4,11 +4,11 @@
 
 import logging
 import sys
+from configparser import ConfigParser
 
 import click
 import pkg_resources
 import pylint.lint
-from configparser import ConfigParser
 
 from .config import AcsooConfig
 from .main import main


### PR DESCRIPTION
This fixes the `TypeError: __init__() got an unexpected keyword argument 'exit'` error.

It breaks from this [commit](https://github.com/PyCQA/pylint/commit/4210ef9b8c5d9e7b33ff0542683f18b8031193fa#diff-ade2cfcf3e840a993dbd465f517d91f5L1189) on PyLint.

This solution is taken from [pylint-odoo](https://github.com/OCA/pylint-odoo/commit/5b0f7f9783e607217ec5d7833e15e7dda28122c1#diff-6177c602688f2a88312483059f6523d2R127).
