### PR TITLE
deprecate acsoo pylint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,9 @@ Perform ``acsoo tag``, ``acsoo tag_requirements`` and
 acsoo flake8
 ------------
 
+**This command is deprecated, use a .flake8 file in your project,
+in combination with pre-commit. See the project template for a reasonable default.**
+
 Run `flake8 <https://pypi.python.org/pypi/flake8>`_ with sensible default for Odoo code.
 
 It is possible to pass additional options to the ``flake8`` command, eg:
@@ -105,6 +108,9 @@ It is possible to pass additional options to the ``flake8`` command, eg:
 
 acsoo pylint
 ------------
+
+**This command is deprecated, use a .pylintrc file in your project,
+in combination with pre-commit. See the project template for a reasonable default.**
 
 Run `pylint <https://pypi.python.org/pypi/pylint>`_ on detected Odoo addons in odoo/addons,
 odoo_addons or the current directory.
@@ -159,6 +165,7 @@ errors based on regular expressions.
 
 bumpversion
 -----------
+
 Bumpversion is a software automatically installed with acsoo. It allows you to
 increment or simply change the version of the project in several files at once,
 including acsoo.cfg.

--- a/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
+++ b/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
@@ -42,9 +42,13 @@ pre-commit:
   stage: code quality
   tags:
     - python
+  cache:
+    key: pre-commit
+    paths:
+    - .pre-commit
   script:
     - install_pre_commit
-    - ./pre-commit run --all-files
+    - PRE_COMMIT_HOME=$PWD/.pre-commit ./pre-commit run --all-files
 
 build:
   stage: build

--- a/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
+++ b/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
@@ -92,10 +92,16 @@ test:
     # and the server_environment tests require a very specific server_environment_files
     - ADDONS_TEST=$(./acsoo addons --exclude server_environment_files list)
     - echo Testing ${ADDONS_TEST}
-    - unbuffer venv/bin/coverage run venv/bin/{{{ odoocmd }}} -c odoo-ci.cfg -d ${DB_NAME} --stop-after-init --no-xmlrpc -i ${ADDONS_TEST} --test-enable | ./acsoo checklog
+    - unbuffer venv/bin/coverage run --branch venv/bin/{{{ odoocmd }}} -c odoo-ci.cfg -d ${DB_NAME} --stop-after-init --no-xmlrpc -i ${ADDONS_TEST} --test-enable | ./acsoo checklog
+    - venv/bin/coverage html
     - venv/bin/coverage report
     - if [ "${CI_COMMIT_REF_NAME}" = "master" ] ; then makepot ; fi
-  coverage: '/TOTAL\s+\d+\s+\d+\s+(\d+\%)/'
+  coverage: '/TOTAL\s+\d+\s+\d+\s+\d+\s+\d+\s+(\d+\%)/'
+  artifacts:
+    expire_in: 1 week
+    paths:
+      - htmlcov/
+    name: "${CI_PROJECT_NAME}-${CI_JOB_ID}-coverage-html"
   dependencies:
     - build
 

--- a/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
+++ b/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
@@ -38,14 +38,6 @@ variables:
   PYTHON: {{{ python_version }}}
   DB_NAME: "${CI_PROJECT_NAME}-${CI_JOB_ID}"
 
-pylint:
-  stage: code quality
-  tags:
-    - python
-  script:
-    - install_acsoo
-    - ./acsoo pylint
-
 pre-commit:
   stage: code quality
   tags:

--- a/acsoo/templates/project/+project.name+/.pre-commit-config.yaml
+++ b/acsoo/templates/project/+project.name+/.pre-commit-config.yaml
@@ -25,6 +25,17 @@ repos:
     args: [--ignore=F401]  # ignore imported unused in __init__.py
     files: __init__.py
     language_version: python3.6
+- repo: https://github.com/pre-commit/mirrors-pylint
+  rev: v2.3.1
+  hooks:
+  - id: pylint
+    name: pylint odoo
+    # check only specific Odoo addons
+    files: odoo/addons/
+    types: ['file', 'python']   # to not check .csv and .conf files
+    args: []
+    additional_dependencies: [pylint-odoo==3.0.1]
+    language_version: python3.6
 - repo: https://github.com/asottile/pyupgrade
   rev: v1.6.1
   hooks:

--- a/acsoo/templates/project/+project.name+/.pylintrc.bob
+++ b/acsoo/templates/project/+project.name+/.pylintrc.bob
@@ -1,0 +1,109 @@
+[MASTER]
+
+load-plugins=pylint_odoo
+
+ignore=
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+enable=all
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=
+  access-member-before-definition,
+  attribute-defined-outside-init,
+  bare-except,
+  duplicate-code,
+  import-error,
+  invalid-name,
+  missing-docstring,
+  missing-newline-extrafiles,
+  missing-readme,
+  no-init,
+  no-member,
+  no-name-in-module,
+  no-self-use,
+  protected-access,
+  suppressed-message,
+  too-few-public-methods,
+  too-many-arguments,
+  too-many-boolean-expressions,
+  too-many-branches,
+  too-many-function-args,
+  too-many-instance-attributes,
+  too-many-lines,
+  too-many-locals,
+  too-many-nested-blocks,
+  too-many-public-methods,
+  too-many-return-statements,
+  too-many-statements,
+  unused-argument,
+  C0330,
+  attribute-string-redundant,
+  fixme,
+  locally-disabled,
+
+extension-pkg-whitelist=lxml
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=colorized
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+msg-template={path}:{line}:{column}: {msg_id} {msg} ({symbol})
+
+[ODOOLINT]
+
+valid_odoo_versions={{{ odoo.series }}}
+
+# URL of README.rst template file
+readme_template_url=https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst
+
+# List of extension files to check separated by a comma.
+extfiles_to_lint=xml,csv,po,js,mako
+
+# Name of author required in manifest file.
+manifest_required_authors=ACSONE SA/NV
+
+# List of keys required in manifest file, separated by a comma.
+manifest_required_keys=license,author
+
+# List of keys deprecated in manifest file, separated by a comma.
+manifest_deprecated_keys=
+
+# List of license allowed in manifest file, separated by a comma.
+license_allowed=AGPL-3,LGPL-3,Other proprietary
+
+# List of attributes deprecated, separated by a comma.
+attribute_deprecated=_columns,_defaults
+
+# List of methods where call to `super` is required.separated by a comma.
+method_required_super=create,write,read,unlink,copy,setUp,setUpClass,tearDown,default_get
+
+# Regex to check version format in manifest file
+manifest_version_format=(\d+.\d+.\d+.\d+.\d+)
+
+# List of cursor expr separated by a comma.
+cursor_expr=self.env.cr,self._cr,self.cr,cr


### PR DESCRIPTION
- configure using regular pylint config
- provide a default config in project template
- use pre-commit to run pylint (with all associated benefits)
- deprecate acsoo flake8 too (it was already deprecated in the project template)

Main benefits are
- pre-commit allows for earlier detection of issues (at commit time)
- local configuration allows easy integration of pylint in IDE
- one less dependency on acsoo so you learn standard tools, not proprietary stuff

@acsone/acsone-odoo-team 