### PR TITLE
[FIX] Project Template: remote utf-8 header in python file unnecessary

### DIFF
--- a/acsoo/templates/project/+project.name+/odoo/addons/+project.trigram+_all/__init__.py
+++ b/acsoo/templates/project/+project.name+/odoo/addons/+project.trigram+_all/__init__.py
@@ -1,3 +1,0 @@
-# -*- coding: utf-8 -*-
-# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).

--- a/acsoo/templates/project/+project.name+/odoo/addons/+project.trigram+_all/__manifest__.py.bob
+++ b/acsoo/templates/project/+project.name+/odoo/addons/+project.trigram+_all/__manifest__.py.bob
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+{{% if odoo.series == '10.0' %}}# -*- coding: utf-8 -*-{{% endif %}}
 # Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {

--- a/acsoo/templates/project/+project.name+/odoo/addons/server_environment_files/__manifest__.py.bob
+++ b/acsoo/templates/project/+project.name+/odoo/addons/server_environment_files/__manifest__.py.bob
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+{{% if odoo.series == '10.0' %}}# -*- coding: utf-8 -*-{{% endif %}}
 # Copyright 2020 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 


### PR DESCRIPTION
Match pylint-odoo C8202 check.