### PR TITLE
[ADD] Project Template: merge request templates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changes
 .. ----------
 .. -
 
+- [IMP] project template: merge request templates
 - [IMP] support non-editable VCS requirements in tag_requirements command
 - [DEL] remove --force option of tag_requirements command
   as it does nothing useful, since all we want of this command

--- a/acsoo/templates/project/+project.name+/.gitlab/merge_request_templates/Review.md
+++ b/acsoo/templates/project/+project.name+/.gitlab/merge_request_templates/Review.md
@@ -1,0 +1,6 @@
+### Issues
+- [ ] fixes #
+
+/label ~"needs review"
+/milestone %1.0
+/target_branch master

--- a/acsoo/templates/project/+project.name+/.gitlab/merge_request_templates/WIP.md
+++ b/acsoo/templates/project/+project.name+/.gitlab/merge_request_templates/WIP.md
@@ -1,0 +1,7 @@
+### Issues
+- [ ] fixes #
+
+/label ~"work in progress"
+/milestone %1.0
+/target_branch master
+/wip


### PR DESCRIPTION
This PR adds two examples of [GitLab merge request templates](https://docs.gitlab.com/ee/user/project/description_templates.html#creating-merge-request-templates).

When creating a merge request, a template can be selected, filling the description field. [GitLab Quick Actions](https://docs.gitlab.com/ee/user/project/quick_actions.html) are used to automatically fill some fields (labels, milestone, target branch, assignee) at save.

Used variables such as labels, milestones, branches and users must exist in the project or won't be applied.

The _Review_ template could be improved at the project level with `/assign @{user_name}` to automatically assign the MR to the reviewer.

The _WIP_ template toggles the [WIP mode](https://docs.gitlab.com/ee/user/project/merge_requests/work_in_progress_merge_requests.html) on the MR.

When accepting the MR, checking `Include merge request description` will automatically close/resolve the related issue at merge (since `fixes #{issue_number}` will be included in the merge commit).

The milestone could be automatically updated by `bumpversion`.