### PR TITLE
[IMP] Project Template: set flake8 max. line length to 80

### DIFF
--- a/acsoo/templates/project/+project.name+/.flake8
+++ b/acsoo/templates/project/+project.name+/.flake8
@@ -1,4 +1,5 @@
 [flake8]
+max-line-length = 80
 max-complexity = 12
 # B = bugbear
 # B9 = bugbear opinionated (incl line length)


### PR DESCRIPTION
Align Black and Flake8 configuration by setting the maximum line length to 80 characters to avoid B950 (line too long) error.
https://github.com/psf/black#line-length