### PR TITLE
[IMP] Add the Skip CI into push option of makepot script.

### DIFF
--- a/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
+++ b/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
@@ -24,7 +24,7 @@ before_script:
     function makepot {
         # if you use weblate, remove --msgmerge here and install the msgmerge addon on weblate
         venv/bin/click-odoo-makepot -c odoo-ci.cfg -d ${DB_NAME} --commit --msgmerge --addons-dir=$(pwd)/odoo/addons
-        git push "git@gitlab.acsone.eu:${CI_PROJECT_PATH}" "HEAD:${CI_COMMIT_REF_NAME}"
+        git push --push-option ci.skip "git@gitlab.acsone.eu:${CI_PROJECT_PATH}" "HEAD:${CI_COMMIT_REF_NAME}"
     }
 
 after_script:


### PR DESCRIPTION
This makepot shouldn't change anything to tests and shouldn't use resources of gitlab-ci.

It's already added in some projects.