### PR TITLE
[ADD] acsoo pr-status

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -6,4 +6,4 @@ force_grid_wrap=0
 combine_as_imports=True
 use_parentheses=True
 line_length=88
-known_third_party = appdirs,click,pkg_resources,pylint,setuptools
+known_third_party = appdirs,click,httpx,pkg_resources,pylint,respx,setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,6 @@ jobs:
       script: tox
       env: TOXENV=check_readme
     - stage: test
-      python: "2.7"
-      script: tox -e py27
-    - stage: test
-      python: "3.5"
-      script: tox -e py35
-    - stage: test
       python: "3.6"
       script: tox -e py36
     - stage: test

--- a/acsoo/__init__.py
+++ b/acsoo/__init__.py
@@ -10,6 +10,7 @@ from . import main
 from . import addons
 from . import checklog
 from . import flake8cmd
+from . import pr_status
 from . import pylintcmd
 from . import release
 from . import tag

--- a/acsoo/pr_status.py
+++ b/acsoo/pr_status.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License GPL-3.0 or later (http://www.gnu.org/licenses/gpl.html).
+
+import logging
+import os
+import re
+from collections import namedtuple
+
+import click
+import httpx
+
+from .main import main
+
+_logger = logging.getLogger(__name__)
+
+
+PR = namedtuple("PR", ["org", "repo", "pr"])
+PR_RE = re.compile(
+    r".*github.com.(?P<org>[a-zA-Z-_]+)/(?P<repo>[a-zA-Z-_]+)"
+    r".*@refs/pull/(?P<pr>[0-9]+)/head"
+)
+
+
+def looks_like_req_file(filename):
+    return ("requirements" in filename or "constraints" in filename) and (
+        filename.endswith(".txt") or filename.endswith(".txt.in")
+    )
+
+
+def display_state(rjson):
+    state = rjson["state"]
+    merged = rjson["merged"]
+    if state == "open":
+        return click.style("open", fg="white")
+    elif state == "closed" and merged:
+        return click.style("merged", fg="magenta")
+    elif state == "closed" and not merged:
+        return click.style("closed", fg="red")
+    else:
+        return click.style(state, fg="yellow")
+
+
+@click.command()
+def pr_status():
+    """Show status of PR found in requirement files."""
+    for reqfile in os.listdir("."):
+        prs = []
+        if not looks_like_req_file(reqfile):
+            continue
+        click.secho("Scanning " + reqfile, dim=True)
+        with open(reqfile) as f:
+            for line in f:
+                mo = PR_RE.match(line)
+                if not mo:
+                    continue
+                prs.append(PR(**mo.groupdict()))
+        for pr in prs:
+            r = httpx.get(
+                f"https://api.github.com/repos/{pr.org}/{pr.repo}/pulls/{pr.pr}"
+            )
+            r.raise_for_status()
+            state = display_state(r.json())
+            click.echo(f"https://github.com/{pr.org}/{pr.repo}/pull/{pr.pr} is {state}")
+
+
+main.add_command(pr_status)

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
   setuptools>=20,<31
   wheel>=0.29
   bumpversion
+  httpx
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,8 +8,6 @@ classifiers =
   Intended Audience :: Developers
   License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
   Operating System :: POSIX
-  Programming Language :: Python :: 2.7
-  Programming Language :: Python :: 3.5
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
@@ -18,7 +16,7 @@ classifiers =
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
+python_requires = >=3.6
 install_requires =
   appdirs
   bobtemplates.odoo
@@ -36,7 +34,3 @@ install_requires =
 [options.entry_points]
 console_scripts =
   acsoo = acsoo.main:main
-
-[bdist_wheel]
-# support py2 and py3
-universal = True

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-cov
+pytest-mock

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
 pytest-mock
+respx

--- a/tests/test_pr_status.py
+++ b/tests/test_pr_status.py
@@ -1,0 +1,40 @@
+import textwrap
+
+import respx
+from click.testing import CliRunner
+
+from acsoo.pr_status import pr_status
+
+
+@respx.mock
+def test_pr_status_basic():
+    req1 = respx.get(
+        "https://api.github.com/repos/OCA/mis-builder/pulls/298",
+        content='{"state": "closed", "merged": false}',
+    )
+    req2 = respx.get(
+        "https://api.github.com/repos/OCA/server-tools/pulls/100",
+        content='{"state": "closed", "merged": true}',
+    )
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("requirements.txt.in", "w") as f:
+            f.write(
+                textwrap.dedent(
+                    """\
+                    # closed not merged
+                    -e git+https//github.com/OCA/mis-builder@refs/pull/298/head#\
+                    subdirectory=setup/mis_builder&egg=odoo13-addon-mis_builder
+                    # closed and merged
+                    odoo10-addon-suspend_security @ \
+                    git+https//github.com/OCA/server-tools@refs/pull/100/head#\
+                    subdirectory=setup/suspend_security
+                    """
+                )
+            )
+        res = runner.invoke(pr_status, color=False)
+        assert req1.called
+        assert req2.called
+        assert res.exit_code == 0
+        assert "OCA/mis-builder/pull/298 is closed" in res.output
+        assert "OCA/server-tools/pull/100 is merged" in res.output

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,6 @@
 
 [tox]
 envlist =
-  py27
-  py35
   py36
   py37
   py38

--- a/tox.ini
+++ b/tox.ini
@@ -14,10 +14,7 @@ envlist =
 [testenv]
 usedevelop = True
 commands = py.test --cov-config=.coveragerc --cov=acsoo --cov-branch --ignore=tests/data {posargs}
-deps =
-  pytest
-  pytest-cov
-  pytest-mock
+deps = -r test-requirements.txt
 
 [testenv:check_readme]
 description = check that the long description is valid (need for PyPi)


### PR DESCRIPTION
This is a step towards not needing to use gitaggregate for the most common case where we install an addon from a PR.

It gets the PR references (of the form `@refs/pull/NNN/head`) from a python requirements file.

The next step will be to make `acsoo tag-requirements` capable of automatically pushing the PR to the acsone organization where it can tag it.
