### PR TITLE
License check, and deprecate acsoo addons in favor of manifestoo

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Changes
   `#77 <https://github.com/acsone/acsoo/pull/77>`_.
 - In acsoo tag, do not complain about empty directories `#76
   <https://github.com/acsone/acsoo/pull/76>`_.
+- Deprecate ``acsoo freeze`` in favor of ``pip-deepfreeze``.
+- Deprecate ``acsoo addons`` in favor of ``manifestoo``.
 
 3.0.2 (2020-10-14)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Changes
   <https://github.com/acsone/acsoo/pull/76>`_.
 - Deprecate ``acsoo freeze`` in favor of ``pip-deepfreeze``.
 - Deprecate ``acsoo addons`` in favor of ``manifestoo``.
+- Add license and development status check to project template.
 
 3.0.2 (2020-10-14)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -88,16 +88,6 @@ acsoo tag-requirements
 Tag all VCS requirements found in ``requirements.txt``, so
 the referenced commits are not lost in case of VCS garbage collection.
 
-acsoo addons
-------------
-
-A set of commands to print addons lists, useful when running tests.
-
-  .. code:: shell
-
-     acsoo addons list
-     acsoo addons list-depends
-
 acsoo checklog
 --------------
 
@@ -131,6 +121,20 @@ of your project. See the bumpversion `documentation
 
 Deprecated commands
 ~~~~~~~~~~~~~~~~~~~
+
+acsoo addons
+------------
+
+**acsoo addons is deprecated: use `manifestoo
+<https://pypi.org/project/manifestoo>`_ instead: it is more robust and has
+better test coverage.**
+
+A set of commands to print addons lists, useful when running tests.
+
+  .. code:: shell
+
+     acsoo addons list
+     acsoo addons list-depends
 
 acsoo freeze
 ------------

--- a/README.rst
+++ b/README.rst
@@ -71,12 +71,6 @@ Initialize a new project
     cd {project name}
     mkvirtualenv {project name} -a .
 
-acsoo freeze
-------------
-
-Just like pip freeze, except it outputs only dependencies of the provided
-distribution name.
-
 acsoo pr-status
 ---------------
 
@@ -137,6 +131,15 @@ of your project. See the bumpversion `documentation
 
 Deprecated commands
 ~~~~~~~~~~~~~~~~~~~
+
+acsoo freeze
+------------
+
+**Deprecated: use `pip-deepfreeze <https://pypi.org/project/pip-deepfreeze>`_
+instead.**
+
+Just like pip freeze, except it outputs only dependencies of the provided
+distribution name.
 
 acsoo wheel
 -----------

--- a/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
+++ b/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
@@ -69,7 +69,7 @@ test:
     # use --no-index so missing dependencies that would not be in *.whl are detected
     # install the project in editable mode (-e) so coverage sees it
     - venv/bin/pip install --no-index --find-links release -e .
-    - manifestoo -d odoo/addons --addons-path-python=venv/bin/python check-licenses
+    - unbuffer manifestoo -d odoo/addons --addons-path-python=venv/bin/python check-licenses
     - ADDONS_INIT=$(manifestoo -d odoo/addons list-depends --separator=,)
     - echo Installing ${ADDONS_INIT}
     - unbuffer venv/bin/click-odoo-initdb -c odoo-ci.cfg --new-database ${DB_NAME} --cache-prefix {{{ project.trigram }}} -m ${ADDONS_INIT} | acsoo checklog

--- a/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
+++ b/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
@@ -5,11 +5,6 @@ stages:
 
 before_script:
   - |
-    function install_acsoo {
-        virtualenv --python=$PYTHON venv-acsoo
-        venv-acsoo/bin/pip install acsoo
-        ln -s venv-acsoo/bin/acsoo
-    }
     function start_ssh_agent {
         eval $(ssh-agent -s)
         ssh-add <(echo "$SSH_DEPLOY_KEY")
@@ -67,19 +62,19 @@ test:
   tags:
     - odoo-{{{ odoo.series }}}
   script:
-    - install_acsoo
+    - pipx install acsoo
     - start_ssh_agent  # for pushing translations
     - virtualenv --python=$PYTHON venv
     - venv/bin/pip install coverage
     # use --no-index so missing dependencies that would not be in *.whl are detected
     # install the project in editable mode (-e) so coverage sees it
     - venv/bin/pip install --no-index --find-links release -e .
-    - ADDONS_INIT=$(./acsoo addons list-depends)
+    - ADDONS_INIT=$(acsoo addons list-depends)
     - echo Installing ${ADDONS_INIT}
-    - unbuffer venv/bin/click-odoo-initdb -c odoo-ci.cfg --new-database ${DB_NAME} --cache-prefix {{{ project.trigram }}} -m ${ADDONS_INIT} | ./acsoo checklog
-    - ADDONS_TEST=$(./acsoo addons list)
+    - unbuffer venv/bin/click-odoo-initdb -c odoo-ci.cfg --new-database ${DB_NAME} --cache-prefix {{{ project.trigram }}} -m ${ADDONS_INIT} | acsoo checklog
+    - ADDONS_TEST=$(acsoo addons list)
     - echo Testing ${ADDONS_TEST}
-    - unbuffer venv/bin/coverage run --branch venv/bin/{{{ odoocmd }}} -c odoo-ci.cfg -d ${DB_NAME} --stop-after-init --no-xmlrpc -i ${ADDONS_TEST} --test-enable | ./acsoo checklog
+    - unbuffer venv/bin/coverage run --branch venv/bin/{{{ odoocmd }}} -c odoo-ci.cfg -d ${DB_NAME} --stop-after-init --no-xmlrpc -i ${ADDONS_TEST} --test-enable | acsoo checklog
     - venv/bin/coverage html
     - venv/bin/coverage report
     - if [ "${CI_COMMIT_REF_NAME}" = "master" ] ; then makepot ; fi

--- a/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
+++ b/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
@@ -37,7 +37,7 @@ build:
   stage: build
   # use odoo-{{{ odoo.series }}} runner so we have the pre-cloned odoo
   # except for that optimization, we don't need odoo dependencies for this job
-  image: ghcr.io/acsone/odoo-ci-image:v20210525.1
+  image: ghcr.io/acsone/odoo-ci-image:v20210526.0
   tags:
     - odoo-{{{ odoo.series }}}
   script:
@@ -58,7 +58,7 @@ build:
 {{% endif %}}
 test:
   stage: test
-  image: ghcr.io/acsone/odoo-ci-image:v20210525.1
+  image: ghcr.io/acsone/odoo-ci-image:v20210526.0
   tags:
     - odoo-{{{ odoo.series }}}
   script:

--- a/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
+++ b/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
@@ -70,6 +70,7 @@ test:
     # install the project in editable mode (-e) so coverage sees it
     - venv/bin/pip install --no-index --find-links release -e .
     - unbuffer manifestoo -d odoo/addons --addons-path-python=venv/bin/python check-licenses
+    - unbuffer manifestoo -d odoo/addons --addons-path-python=venv/bin/python check-dev-status --default-dev-status=Beta
     - ADDONS_INIT=$(manifestoo -d odoo/addons list-depends --separator=,)
     - echo Installing ${ADDONS_INIT}
     - unbuffer venv/bin/click-odoo-initdb -c odoo-ci.cfg --new-database ${DB_NAME} --cache-prefix {{{ project.trigram }}} -m ${ADDONS_INIT} | acsoo checklog

--- a/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
+++ b/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
@@ -42,6 +42,7 @@ build:
   stage: build
   # use odoo-{{{ odoo.series }}} runner so we have the pre-cloned odoo
   # except for that optimization, we don't need odoo dependencies for this job
+  image: ghcr.io/acsone/odoo-ci-image:v20210525.1
   tags:
     - odoo-{{{ odoo.series }}}
   script:
@@ -62,7 +63,7 @@ build:
 {{% endif %}}
 test:
   stage: test
-  image: quay.io/acsone/odoo-ci:v20210312.0
+  image: ghcr.io/acsone/odoo-ci-image:v20210525.1
   tags:
     - odoo-{{{ odoo.series }}}
   script:

--- a/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
+++ b/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
@@ -69,6 +69,7 @@ test:
     # use --no-index so missing dependencies that would not be in *.whl are detected
     # install the project in editable mode (-e) so coverage sees it
     - venv/bin/pip install --no-index --find-links release -e .
+    - manifestoo -d odoo/addons --addons-path-python=venv/bin/python check-licenses
     - ADDONS_INIT=$(manifestoo -d odoo/addons list-depends --separator=,)
     - echo Installing ${ADDONS_INIT}
     - unbuffer venv/bin/click-odoo-initdb -c odoo-ci.cfg --new-database ${DB_NAME} --cache-prefix {{{ project.trigram }}} -m ${ADDONS_INIT} | acsoo checklog

--- a/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
+++ b/acsoo/templates/project/+project.name+/.gitlab-ci.yml.bob
@@ -62,17 +62,17 @@ test:
   tags:
     - odoo-{{{ odoo.series }}}
   script:
-    - pipx install acsoo
+    - pipx install acsoo  # for checklog
     - start_ssh_agent  # for pushing translations
     - virtualenv --python=$PYTHON venv
     - venv/bin/pip install coverage
     # use --no-index so missing dependencies that would not be in *.whl are detected
     # install the project in editable mode (-e) so coverage sees it
     - venv/bin/pip install --no-index --find-links release -e .
-    - ADDONS_INIT=$(acsoo addons list-depends)
+    - ADDONS_INIT=$(manifestoo -d odoo/addons list-depends --separator=,)
     - echo Installing ${ADDONS_INIT}
     - unbuffer venv/bin/click-odoo-initdb -c odoo-ci.cfg --new-database ${DB_NAME} --cache-prefix {{{ project.trigram }}} -m ${ADDONS_INIT} | acsoo checklog
-    - ADDONS_TEST=$(acsoo addons list)
+    - ADDONS_TEST=$(manifestoo -d odoo/addons list --separator=,)
     - echo Testing ${ADDONS_TEST}
     - unbuffer venv/bin/coverage run --branch venv/bin/{{{ odoocmd }}} -c odoo-ci.cfg -d ${DB_NAME} --stop-after-init --no-xmlrpc -i ${ADDONS_TEST} --test-enable | acsoo checklog
     - venv/bin/coverage html


### PR DESCRIPTION
[Manifestoo](https://pypi.org/project/manifestoo/) is an evolution of `acsoo addons` with better test coverage and more features.

In particular, it provides a `check-licenses` command to help ensure we don't mix proprietary and xGPL code.

Similarly, `check-dev-status` helps avoiding the use of Alpha-level OCA modules.

Also, use our latest odoo ci image which has pipx pre-installed, simplifying installation of python tools such as acsoo itself (which we still need in CI for the `checklog` command).