### PR TITLE
Remove bumpversion from acsoo dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Changes
 - Deprecate ``acsoo freeze`` in favor of ``pip-deepfreeze``.
 - Deprecate ``acsoo addons`` in favor of ``manifestoo``.
 - Add license and development status check to project template.
+- Remove bumpversion from acsoo dependencies. This project is now replaced by
+  bump2versions, and it's better to install it separately with pipx.
 
 3.0.2 (2020-10-14)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -43,11 +43,7 @@ or
 
    Since ``acsoo`` has a lot of dependencies that are not required at runtime,
    for your application, it is not recommanded to install it in the same
-   virtualenv as your project. A good approach is to install it in it's own
-   virtual env and symlink the ``acsoo``, ``mrbob`` and ``bumpversion``
-   executables somewhere in your PATH. `pipx <https://pypi.org/project/pipx/>`_
-   is an interesting way to manage such python scripts without polluting your
-   system.
+   virtualenv as your project.
 
 To enable bash completion, add this line in your ``.bashrc``:
 
@@ -99,25 +95,6 @@ errors based on regular expressions.
      acsoo checklog odoo.log
      odoo -d mydb -i base --stop-after-init | acsoo checklog
      acsoo checklog --ignore "WARNING.*blah" odoo.log
-
-bumpversion
------------
-
-Bumpversion is a software automatically installed with acsoo. It allows you to
-increment or simply change the version of the project in several files at once,
-including acsoo.cfg.
-
-  .. code:: shell
-
-    bumpversion {part}
-
-Where part is 'major', 'minor' or 'patch'
-(see `semantic versioning <http://semver.org/>`_).
-
-Configure bumpversion by editing the .bumpversion.cfg config file at the root
-of your project. See the bumpversion `documentation
-<https://pypi.python.org/pypi/bumpversion>`_ to go further
-(automatic commit, tag, customisation...).
 
 Deprecated commands
 ~~~~~~~~~~~~~~~~~~~

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ install_requires =
   pylint-odoo==3.1.0
   setuptools  # must use odoo-autodiscover>=2 in Odoo<=10
   wheel>=0.29
-  bumpversion
   httpx
 
 [options.entry_points]


### PR DESCRIPTION
This project is now replaced by bump2versions, and it's better to install it separately with pipx.