### PR TITLE
lazy-object-proxy version restriction for python2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ packages = find:
 include_package_data = True
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 install_requires =
+  lazy-object-proxy<1.7
   appdirs
   click
   colorama
@@ -39,3 +40,4 @@ console_scripts =
 [bdist_wheel]
 # support py2 and py3
 universal = True
+


### PR DESCRIPTION
As the version 1.7 of lazy-object-proxy does not provide support for python2.7, we should use the previous one.