### PR TITLE
[ADD] Support Odoo 16

### DIFF
--- a/acsoo/config.py
+++ b/acsoo/config.py
@@ -47,7 +47,17 @@ class AcsooConfig(object):
         r = self.__cfg.get(SECTION, "series")
         if not r:
             raise click.ClickException("Missing series in {}.".format(self.__cfgfile))
-        if r not in ("8.0", "9.0", "10.0", "11.0", "12.0", "13.0", "14.0", "15.0"):
+        if r not in (
+            "8.0",
+            "9.0",
+            "10.0",
+            "11.0",
+            "12.0",
+            "13.0",
+            "14.0",
+            "15.0",
+            "16.0",
+        ):
             raise click.ClickException(
                 "Unsupported series {} in {}.".format(r, self.__cfgfile)
             )

--- a/acsoo/templates/project/.mrbob.ini
+++ b/acsoo/templates/project/.mrbob.ini
@@ -5,7 +5,7 @@ project.name.required = True
 project.trigram.question = Project trigram (3 lowercase letters)
 project.trigram.required = True
 
-odoo.series.question = Odoo series (8.0, 9.0, 10.0, 11.0, 13.0, 14.0, 15.0)
+odoo.series.question = Odoo series (8.0, 9.0, 10.0, 11.0, 13.0, 14.0, 15.0, 16.0)
 odoo.series.default = 14.0
 odoo.series.required = True
 


### PR DESCRIPTION
Add possibility to use `acsoo` with Odoo `16.0`.

For now I only test this command who works perfectly:
`acsoo tag-requirements`

I did a secondary commit about a little improvement, to generate automatically supported Odoo versions.