### PR TITLE
[IMP] Project Template - Use a newer configuration for eslintrc

### DIFF
--- a/acsoo/templates/project/+project.name+/.eslintrc.yml
+++ b/acsoo/templates/project/+project.name+/.eslintrc.yml
@@ -3,7 +3,8 @@ env:
 
 # See https://github.com/OCA/odoo-community.org/issues/37#issuecomment-470686449
 parserOptions:
-  ecmaVersion: 2017
+  ecmaVersion: 2019
+  sourceType: module
 
 # Globals available in Odoo that shouldn't produce errorings
 globals:


### PR DESCRIPTION
The previous eslinrtc configuration file wasn't working with odoo 16, because the sourceType key was missing. 
Upgrade ecmaVersion to 2019 adds new tokens that are used in odoo JS.