### PR TITLE
[FIX] pr_status: manage PR URL's containing numerical characters

### DIFF
--- a/acsoo/pr_status.py
+++ b/acsoo/pr_status.py
@@ -17,8 +17,7 @@ _logger = logging.getLogger(__name__)
 
 PR = namedtuple("PR", ["org", "repo", "pr"])
 PR_RE = re.compile(
-    r".*github.com.(?P<org>[a-zA-Z-_]+)/(?P<repo>[a-zA-Z-_]+)"
-    r".*@refs/pull/(?P<pr>[0-9]+)/head"
+    r".*github.com.(?P<org>[^/]+)/(?P<repo>[^/]+)" r".*@refs/pull/(?P<pr>[0-9]+)/head"
 )
 PR_URL_RE = re.compile(
     r".*https://github.com/(?P<org>[^/]+)/(?P<repo>[^/]+)/pull/(?P<pr>[0-9]+).*"


### PR DESCRIPTION
The organization name and the repository can contain digits.

E.g. https://github.com/OCA/l10n-belgium